### PR TITLE
Streamlined in-app updates (v1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.1] - 2026-02-15
+
+### Changed
+- Streamlined in-app updates: LunarLog now guides users through download, "allow installs from this app", and installation without sending them to GitHub.
+- Update checks are disabled for debug builds to avoid signature mismatch install failures.
+
 ## [1.6.0] - 2026-02-15
 
 ### Changed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.lunarlog"
         minSdk = 26
         targetSdk = 34
-        versionCode = 10
-        versionName = "1.6.0"
+        versionCode = 11
+        versionName = "1.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/lunarlog/MainActivity.kt
+++ b/app/src/main/java/com/lunarlog/MainActivity.kt
@@ -44,7 +44,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.remember
 import com.lunarlog.update.ApkUpdateManager
-import kotlinx.coroutines.delay
+import com.lunarlog.ui.update.UpdateBottomSheet
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -60,9 +60,6 @@ class MainActivity : AppCompatActivity() {
         // Silent update check (GitHub Releases).
         viewModel.checkForUpdates()
 
-        // If a previous download completed, prompt install on next launch.
-        apkUpdateManager.maybePromptInstallDownloadedApk(this)
-        
         // Keep splash screen until data is loaded
         splashScreen.setKeepOnScreenCondition {
             viewModel.uiState.value.isLoading
@@ -74,16 +71,34 @@ class MainActivity : AppCompatActivity() {
             val uiState by viewModel.uiState.collectAsState()
             val isLocked by viewModel.isLocked.collectAsState()
             val snackbarHostState = remember { SnackbarHostState() }
+            val updateSheetInfo = remember { androidx.compose.runtime.mutableStateOf<com.lunarlog.update.UpdateInfo?>(null) }
+            val promptedDownloaded = remember { androidx.compose.runtime.mutableStateOf(false) }
 
-            // Handle Install Trigger
+            // Handle Install Trigger (opens the guided in-app updater UI).
             LaunchedEffect(Unit) {
                 viewModel.installUpdateTrigger.collect { info ->
-                    apkUpdateManager.startDownload(this@MainActivity, info)
-                    // Poll briefly so we can prompt install as soon as the download completes
-                    // while the user remains in the app.
-                    repeat(120) {
-                        delay(1_000)
-                        if (apkUpdateManager.maybePromptInstallDownloadedApk(this@MainActivity)) return@repeat
+                    updateSheetInfo.value = info
+                }
+            }
+
+            // If an update was downloaded previously, offer install without surprise navigation.
+            LaunchedEffect(Unit) {
+                if (promptedDownloaded.value) return@LaunchedEffect
+                if (!apkUpdateManager.hasDownloadedApk(this@MainActivity)) return@LaunchedEffect
+                promptedDownloaded.value = true
+
+                val needsPerm = apkUpdateManager.needsUnknownSourcesPermission(this@MainActivity)
+                val result = snackbarHostState.showSnackbar(
+                    message = if (needsPerm) "Update downloaded. Enable installs to finish." else "Update downloaded. Ready to install.",
+                    actionLabel = if (needsPerm) "Enable" else "Install",
+                    duration = SnackbarDuration.Long
+                )
+                if (result == SnackbarResult.ActionPerformed) {
+                    if (needsPerm) {
+                        startActivity(apkUpdateManager.buildUnknownSourcesSettingsIntent(this@MainActivity))
+                    } else {
+                        apkUpdateManager.buildInstallIntentFromDownloadedApk(this@MainActivity)
+                            ?.let { startActivity(it) }
                     }
                 }
             }
@@ -136,6 +151,15 @@ class MainActivity : AppCompatActivity() {
                          // Fallback, though splash screen should cover this
                          Box(Modifier.fillMaxSize())
                     }
+
+                    val info = updateSheetInfo.value
+                    if (info != null) {
+                        UpdateBottomSheet(
+                            info = info,
+                            apkUpdateManager = apkUpdateManager,
+                            onDismiss = { updateSheetInfo.value = null }
+                        )
+                    }
                 }
             }
         }
@@ -143,7 +167,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        apkUpdateManager.maybePromptInstallDownloadedApk(this)
     }
 
     private fun authenticateUser() {

--- a/app/src/main/java/com/lunarlog/MainViewModel.kt
+++ b/app/src/main/java/com/lunarlog/MainViewModel.kt
@@ -65,6 +65,11 @@ class MainViewModel @Inject constructor(
 
     fun checkForUpdates() {
         viewModelScope.launch {
+            if (BuildConfig.DEBUG) {
+                // Debug builds are often signed differently than release APK assets.
+                _updateInfo.value = null
+                return@launch
+            }
             try {
                 val info = updateRepository.checkForUpdate(
                     owner = "Robertg761",

--- a/app/src/main/java/com/lunarlog/ui/update/UpdateBottomSheet.kt
+++ b/app/src/main/java/com/lunarlog/ui/update/UpdateBottomSheet.kt
@@ -1,0 +1,314 @@
+package com.lunarlog.ui.update
+
+import android.app.DownloadManager
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.lunarlog.update.ApkUpdateManager
+import com.lunarlog.update.UpdateInfo
+import kotlinx.coroutines.delay
+
+private enum class UpdateStage {
+    Available,
+    Downloading,
+    PermissionRequired,
+    ReadyToInstall,
+    Error
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UpdateBottomSheet(
+    info: UpdateInfo,
+    apkUpdateManager: ApkUpdateManager,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scroll = rememberScrollState()
+
+    var stage by remember { mutableStateOf(UpdateStage.Available) }
+    var progress by remember { mutableStateOf<Float?>(null) }
+    var progressText by remember { mutableStateOf<String?>(null) }
+    var errorText by remember { mutableStateOf<String?>(null) }
+    var notesExpanded by remember { mutableStateOf(false) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    fun recomputeStage() {
+        val q = apkUpdateManager.queryDownload(context)
+        stage = when {
+            apkUpdateManager.hasDownloadedApk(context) -> {
+                if (apkUpdateManager.needsUnknownSourcesPermission(context)) UpdateStage.PermissionRequired else UpdateStage.ReadyToInstall
+            }
+            q?.status == DownloadManager.STATUS_RUNNING ||
+                q?.status == DownloadManager.STATUS_PENDING ||
+                q?.status == DownloadManager.STATUS_PAUSED -> UpdateStage.Downloading
+            q?.status == DownloadManager.STATUS_FAILED -> UpdateStage.Error
+            else -> UpdateStage.Available
+        }
+    }
+
+    LaunchedEffect(info.latestVersionName) {
+        recomputeStage()
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                recomputeStage()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(stage) {
+        if (stage != UpdateStage.Downloading) return@LaunchedEffect
+        while (stage == UpdateStage.Downloading) {
+            val q = apkUpdateManager.queryDownload(context)
+            if (q == null) {
+                progress = null
+                progressText = null
+                stage = UpdateStage.Available
+                break
+            }
+
+            when (q.status) {
+                DownloadManager.STATUS_SUCCESSFUL -> {
+                    progress = 1f
+                    progressText = "Download complete"
+                    stage = if (apkUpdateManager.needsUnknownSourcesPermission(context)) {
+                        UpdateStage.PermissionRequired
+                    } else {
+                        UpdateStage.ReadyToInstall
+                    }
+                    break
+                }
+                DownloadManager.STATUS_FAILED -> {
+                    errorText = "Download failed. Please try again."
+                    stage = UpdateStage.Error
+                    break
+                }
+                else -> {
+                    val total = q.totalBytes
+                    val soFar = q.bytesDownloaded
+                    progress = if (total > 0) (soFar.toFloat() / total.toFloat()).coerceIn(0f, 1f) else null
+                    progressText = if (total > 0) {
+                        val pct = ((soFar * 100) / total).coerceIn(0, 100)
+                        "Downloading... $pct%"
+                    } else {
+                        "Downloading..."
+                    }
+                }
+            }
+            delay(750)
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(scroll)
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 20.dp)
+        ) {
+            Text(
+                text = "Update LunarLog",
+                style = MaterialTheme.typography.titleLarge
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "New version: ${info.latestVersionName}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            if (info.releaseNotes.isNotBlank()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text("What's new", style = MaterialTheme.typography.titleMedium)
+                    OutlinedButton(onClick = { notesExpanded = !notesExpanded }) {
+                        Text(if (notesExpanded) "Hide" else "Show")
+                    }
+                }
+                Text(
+                    text = info.releaseNotes.trim(),
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = if (notesExpanded) Int.MAX_VALUE else 6,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            when (stage) {
+                UpdateStage.Available -> {
+                    Text(
+                        text = "Android will show an install prompt. This update is downloaded directly from LunarLog's releases.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        OutlinedButton(onClick = onDismiss) { Text("Not now") }
+                        Spacer(modifier = Modifier.padding(6.dp))
+                        Button(onClick = {
+                            errorText = null
+                            progress = null
+                            progressText = null
+                            apkUpdateManager.startDownload(context, info)
+                            stage = UpdateStage.Downloading
+                        }) {
+                            Text("Download")
+                        }
+                    }
+                }
+
+                UpdateStage.Downloading -> {
+                    Text(
+                        text = progressText ?: "Downloading...",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(10.dp))
+                    if (progress != null) {
+                        LinearProgressIndicator(progress = { progress!! }, modifier = Modifier.fillMaxWidth())
+                    } else {
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        OutlinedButton(onClick = onDismiss) { Text("Close") }
+                    }
+                }
+
+                UpdateStage.PermissionRequired -> {
+                    Text(
+                        text = "To install this update, Android needs you to allow installs from LunarLog one time.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Tap \"Open settings\", enable \"Allow from this source\", then come back here to install.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        OutlinedButton(onClick = onDismiss) { Text("Later") }
+                        Spacer(modifier = Modifier.padding(6.dp))
+                        Button(onClick = {
+                            context.startActivity(apkUpdateManager.buildUnknownSourcesSettingsIntent(context))
+                        }) {
+                            Text("Open settings")
+                        }
+                    }
+                }
+
+                UpdateStage.ReadyToInstall -> {
+                    Text(
+                        text = "Ready to install. Android will show an install prompt.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        OutlinedButton(onClick = onDismiss) { Text("Close") }
+                        Spacer(modifier = Modifier.padding(6.dp))
+                        Button(onClick = {
+                            if (apkUpdateManager.needsUnknownSourcesPermission(context)) {
+                                stage = UpdateStage.PermissionRequired
+                                return@Button
+                            }
+                            val intent = apkUpdateManager.buildInstallIntentFromDownloadedApk(context)
+                            if (intent == null) {
+                                errorText = "Couldn't start installer. Please re-download the update."
+                                stage = UpdateStage.Error
+                                return@Button
+                            }
+                            context.startActivity(intent)
+                        }) {
+                            Text("Install")
+                        }
+                    }
+                }
+
+                UpdateStage.Error -> {
+                    Text(
+                        text = errorText ?: "Something went wrong.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        OutlinedButton(onClick = onDismiss) { Text("Close") }
+                        Spacer(modifier = Modifier.padding(6.dp))
+                        Button(onClick = {
+                            errorText = null
+                            progress = null
+                            progressText = null
+                            apkUpdateManager.startDownload(context, info)
+                            stage = UpdateStage.Downloading
+                        }) {
+                            Text("Try again")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/lunarlog/update/ApkUpdateManager.kt
+++ b/app/src/main/java/com/lunarlog/update/ApkUpdateManager.kt
@@ -16,6 +16,25 @@ class ApkUpdateManager(
     private fun prefs(context: Context) =
         context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
 
+    data class DownloadQueryResult(
+        val status: Int,
+        val bytesDownloaded: Long,
+        val totalBytes: Long,
+        val reason: Int?
+    )
+
+    fun needsUnknownSourcesPermission(context: Context): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            !context.packageManager.canRequestPackageInstalls()
+    }
+
+    fun buildUnknownSourcesSettingsIntent(context: Context): Intent {
+        return Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+            data = Uri.parse("package:${context.packageName}")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
     fun startDownload(context: Context, info: UpdateInfo): Long {
         val fileName = "LunarLog-${info.latestVersionName}.apk"
         val request = DownloadManager.Request(Uri.parse(info.apkUrl))
@@ -34,61 +53,63 @@ class ApkUpdateManager(
         prefs(context).edit()
             .putLong(KEY_DOWNLOAD_ID, downloadId)
             .putString(KEY_APK_PATH, file.absolutePath)
-            .putBoolean(KEY_UNKNOWN_SOURCES_LAUNCHED, false)
             .apply()
 
         return downloadId
     }
 
-    fun maybePromptInstallDownloadedApk(context: Context): Boolean {
-        val p = prefs(context)
-        val downloadId = p.getLong(KEY_DOWNLOAD_ID, -1L)
-        val apkPath = p.getString(KEY_APK_PATH, null) ?: return false
-        if (downloadId <= 0) return false
+    fun queryDownload(context: Context): DownloadQueryResult? {
+        val downloadId = prefs(context).getLong(KEY_DOWNLOAD_ID, -1L)
+        if (downloadId <= 0) return null
 
         val dm = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val cursor = dm.query(DownloadManager.Query().setFilterById(downloadId))
         cursor.use {
-            if (!it.moveToFirst()) return false
+            if (!it.moveToFirst()) return null
             val status = it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
-            if (status != DownloadManager.STATUS_SUCCESSFUL) return false
-        }
-
-        val apkFile = File(apkPath)
-        if (!apkFile.exists()) return false
-
-        // Unknown sources permission gate (API 26+).
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (!context.packageManager.canRequestPackageInstalls()) {
-                // Avoid repeatedly spamming settings while we poll for completion.
-                if (!p.getBoolean(KEY_UNKNOWN_SOURCES_LAUNCHED, false)) {
-                    p.edit().putBoolean(KEY_UNKNOWN_SOURCES_LAUNCHED, true).apply()
-                    val intent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
-                        data = Uri.parse("package:${context.packageName}")
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    }
-                    context.startActivity(intent)
-                }
-                return false
+            val bytesDownloaded = it.getLong(it.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
+            val totalBytes = it.getLong(it.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
+            val reason = try {
+                it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
+            } catch (_: Exception) {
+                null
             }
+            return DownloadQueryResult(
+                status = status,
+                bytesDownloaded = bytesDownloaded,
+                totalBytes = totalBytes,
+                reason = reason
+            )
         }
-        p.edit().putBoolean(KEY_UNKNOWN_SOURCES_LAUNCHED, false).apply()
+    }
+
+    fun hasDownloadedApk(context: Context): Boolean {
+        val apkFile = getDownloadedApkFile(context) ?: return false
+        val q = queryDownload(context) ?: return false
+        return q.status == DownloadManager.STATUS_SUCCESSFUL && apkFile.exists()
+    }
+
+    fun getDownloadedApkFile(context: Context): File? {
+        val apkPath = prefs(context).getString(KEY_APK_PATH, null) ?: return null
+        return File(apkPath)
+    }
+
+    fun buildInstallIntentFromDownloadedApk(context: Context): Intent? {
+        val apkFile = getDownloadedApkFile(context) ?: return null
+        if (!apkFile.exists()) return null
+        if (needsUnknownSourcesPermission(context)) return null
 
         val authority = "${context.packageName}.fileprovider"
         val apkUri = FileProvider.getUriForFile(context, authority, apkFile)
-        val installIntent = Intent(Intent.ACTION_VIEW).apply {
+        return Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(apkUri, "application/vnd.android.package-archive")
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
-
-        context.startActivity(installIntent)
-        return true
     }
 
     companion object {
         private const val KEY_DOWNLOAD_ID = "download_id"
         private const val KEY_APK_PATH = "apk_path"
-        private const val KEY_UNKNOWN_SOURCES_LAUNCHED = "unknown_sources_launched"
     }
 }

--- a/app/src/main/java/com/lunarlog/update/GitHubReleaseApi.kt
+++ b/app/src/main/java/com/lunarlog/update/GitHubReleaseApi.kt
@@ -8,12 +8,16 @@ import java.net.URL
 
 internal data class GitHubLatestReleaseDto(
     val tag_name: String? = null,
+    val html_url: String? = null,
+    val body: String? = null,
+    val published_at: String? = null,
     val assets: List<GitHubAssetDto>? = null
 )
 
 internal data class GitHubAssetDto(
     val name: String? = null,
-    val browser_download_url: String? = null
+    val browser_download_url: String? = null,
+    val size: Long? = null
 )
 
 class GitHubReleaseApi(

--- a/app/src/main/java/com/lunarlog/update/UpdateInfo.kt
+++ b/app/src/main/java/com/lunarlog/update/UpdateInfo.kt
@@ -3,6 +3,10 @@ package com.lunarlog.update
 data class UpdateInfo(
     val latestVersionName: String,
     val apkName: String,
-    val apkUrl: String
+    val apkUrl: String,
+    val releaseNotes: String = "",
+    val releaseUrl: String = "",
+    val apkSizeBytes: Long? = null,
+    val publishedAt: String? = null
 )
 

--- a/app/src/main/java/com/lunarlog/update/UpdateRepository.kt
+++ b/app/src/main/java/com/lunarlog/update/UpdateRepository.kt
@@ -45,10 +45,21 @@ class UpdateRepository @Inject constructor() {
             !name.contains("debug", ignoreCase = true)
         } ?: apkAssets.first()
 
+        val apkSizeBytes = assets
+            .firstOrNull { a ->
+                val n = a.name?.trim().orEmpty()
+                n.equals(apkName, ignoreCase = true)
+            }
+            ?.size
+
         UpdateInfo(
             latestVersionName = latestTag.removePrefix("v"),
             apkName = apkName,
-            apkUrl = apkUrl
+            apkUrl = apkUrl,
+            releaseNotes = latest.body?.trim().orEmpty(),
+            releaseUrl = latest.html_url?.trim().orEmpty(),
+            apkSizeBytes = apkSizeBytes,
+            publishedAt = latest.published_at?.trim()
         )
     }
 }


### PR DESCRIPTION
### What changed\n- Replaced the GitHub-release-page update flow with a guided in-app updater (download -> permission -> install).\n- Added release notes metadata parsing (notes/url/size) for nicer in-app messaging.\n- Disabled update checks on debug builds to avoid signature mismatch confusion.\n\n### Testing\n- :app:test (debug + release unit tests)\n\n### Notes\n- Android will still show the system install prompt (required outside Play Store).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 1.6.1

* **New Features**
  * Streamlined in-app update experience guiding users through download, permission granting, and installation without leaving the app
  * Release notes now displayed in the update interface

* **Improvements**
  * Enhanced handling of previously downloaded APKs with clearer user prompts for installation
  * Update checks disabled for debug builds to prevent signature mismatch errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->